### PR TITLE
Document GitHub Discussions categories

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -1,3 +1,15 @@
 # Community Resources
 
 This directory will house guidelines, onboarding materials, and communication templates to support contributors and maintainers.
+
+## GitHub Discussions
+
+Discussions are enabled on both [`loqa-core`](https://github.com/ambiware-labs/loqa-core/discussions) and [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta/discussions). Use the following categories when starting new threads:
+
+- **Announcements** – Core team updates, release notes, roadmap milestones.
+- **Ideas** – Feature proposals, architectural suggestions, and workflow improvements.
+- **Q&A** – Support questions and troubleshooting help. (Think of this as the “Support” channel.)
+- **Show and tell** – Share prototypes, community projects, and integrations.
+- **Polls** – Quick community feedback on priorities or design drafts.
+
+Moderators should keep category descriptions in sync with this guide and pin an onboarding message to help first-time posters pick the right channel.


### PR DESCRIPTION
## Summary
- enable discussions for  and 
- add guidance on use of discussion categories to 

## Testing
- n/a