### PR TITLE
Launch Extension Labs resources

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -2,6 +2,10 @@
 
 This directory will house guidelines, onboarding materials, and communication templates to support contributors and maintainers.
 
+## Extension Labs
+
+Looking to build or share a skill? Visit [Extension Labs](extension-labs/README.md) for templates, best practices, and the community showcase.
+
 ## GitHub Discussions
 
 Discussions are enabled on both [`loqa-core`](https://github.com/ambiware-labs/loqa-core/discussions) and [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta/discussions). Use the following categories when starting new threads:

--- a/community/extension-labs/README.md
+++ b/community/extension-labs/README.md
@@ -1,0 +1,58 @@
+# Extension Labs
+
+Welcome to Extension Labs — the launchpad for building, sharing, and discovering Loqa skills and adapters.
+
+Our goals:
+- Make it easy for creators to ship high-quality skills that respect Loqa’s local-first ethos.
+- Showcase community work so operators can quickly find trusted extensions.
+- Prepare the ecosystem for the upcoming marketplace MVP.
+
+> First time here? Start with the [Quickstart Workflow](#quickstart-workflow) and the [Skill Templates](templates/) below.
+
+## Quickstart Workflow
+
+1. **Fork or template a starter project**
+   - [TinyGo WASM template](templates/tinygo-skill-template/README.md)
+   - [Exec adapter template](templates/exec-skill-template/README.md)
+2. **Develop locally** using the guidance in [`skills/AUTHORING_GUIDE.md`](https://github.com/ambiware-labs/loqa-core/blob/main/skills/AUTHORING_GUIDE.md) and the formal [`skills spec`](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md).
+3. **Validate your manifest**
+   ```bash
+   go run ./cmd/loqa-skill validate --file skill.yaml
+   ```
+4. **Share your work**
+   - Open a “Show and Tell” thread in [GitHub Discussions](https://github.com/ambiware-labs/loqa-core/discussions).
+   - Submit a PR to add your template/link to this directory.
+   - Prepare for the marketplace by tracking [RFC-0003](https://github.com/ambiware-labs/loqa-meta/blob/main/rfcs/RFC-0003_loqa_marketplace_mvp.md).
+
+## Contributor Showcase
+
+| Skill | Maintainer | Description | Tags |
+| --- | --- | --- | --- |
+| [timer](https://github.com/ambiware-labs/loqa-core/tree/main/skills/examples/timer) | Ambiware Labs | Simple countdown timer that announces completions. | timers, voice |
+| [smart-home-bridge](https://github.com/ambiware-labs/loqa-core/tree/main/skills/examples/smart-home) | Ambiware Labs | Bridges Loqa intents to Home Assistant. | home-automation, voice |
+
+> Have a skill to feature? [Open an issue](https://github.com/ambiware-labs/loqa-meta/issues/new?labels=community&title=Showcase%20submission%3A%20%3Cskill%3E) with links and tags.
+
+## Templates
+
+Starter templates live in the [`templates/`](templates/) subdirectory. Each template includes a README, manifest, and build scripts mirroring the Loqa spec.
+
+- [`templates/tinygo-skill-template`](templates/tinygo-skill-template/README.md)
+- [`templates/exec-skill-template`](templates/exec-skill-template/README.md)
+
+Contribute improvements as you discover best practices.
+
+## Best Practices & Reviews
+
+- Follow the [contribution checklist](checklist.md) before publishing.
+- Validate permissions and declared subjects to avoid runtime rejections.
+- Record test transcripts or scripts to help reviewers verify behaviour.
+- Use semantic versioning and changelog entries for every release.
+
+## Roadmap
+
+- Track open tasks in [loqa-meta#27](https://github.com/ambiware-labs/loqa-meta/issues/27).
+- Marketplace submission guide will land after RFC-0003 is accepted.
+- Looking for collaborators? Drop an idea in the Discussions “Ideas” category.
+
+Let’s build the Loqa ecosystem together.

--- a/community/extension-labs/checklist.md
+++ b/community/extension-labs/checklist.md
@@ -1,0 +1,13 @@
+# Extension Publishing Checklist
+
+Use this checklist before submitting a skill to Extension Labs or the marketplace:
+
+- [ ] Manifest validates with `go run ./cmd/loqa-skill validate --file skill.yaml`
+- [ ] `metadata.version` follows SemVer and matches your release tag
+- [ ] All publish/subscribe subjects are declared and documented
+- [ ] Permissions are minimal and justified (include reasoning in README)
+- [ ] Provide build instructions and runtime dependencies
+- [ ] Attach tests or replay scripts demonstrating core workflows
+- [ ] Include LICENSE and changelog files in the package
+- [ ] Post a “Show and Tell” entry in Discussions with screenshots/logs
+- [ ] (Optional) Prepare marketplace metadata as per RFC-0003 when ready

--- a/community/extension-labs/templates/exec-skill-template/Makefile
+++ b/community/extension-labs/templates/exec-skill-template/Makefile
@@ -1,0 +1,10 @@
+.PHONY: package validate clean
+
+package:
+	tar -czf my-exec-skill.tar.gz skill.yaml scripts
+
+validate:
+	go run ./cmd/loqa-skill validate --file skill.yaml
+
+clean:
+	rm -f my-exec-skill.tar.gz

--- a/community/extension-labs/templates/exec-skill-template/README.md
+++ b/community/extension-labs/templates/exec-skill-template/README.md
@@ -1,0 +1,19 @@
+# Exec Skill Template
+
+Template for skills that call an external executable or script instead of WASM modules.
+
+## Contents
+- `skill.yaml` – manifest configured with `runtime.mode: exec`
+- `scripts/handler.sh` – example shell handler reading JSON from stdin
+- `Makefile` – helper targets for packaging and validation
+
+## Usage
+
+```bash
+git clone https://github.com/ambiware-labs/loqa-core.git skills-lab
+cd skills-lab/community/extension-labs/templates/exec-skill-template
+make package
+make validate
+```
+
+The runtime will invoke your script with the event payload on stdin. Ensure the manifest permissions and subjects align with the behaviour.

--- a/community/extension-labs/templates/exec-skill-template/scripts/handler.sh
+++ b/community/extension-labs/templates/exec-skill-template/scripts/handler.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload=$(cat)
+logger "[loqa-exec] received payload: $payload"
+
+cat <<JSON
+{"reply":"Hello from exec skill"}
+JSON

--- a/community/extension-labs/templates/exec-skill-template/skill.yaml
+++ b/community/extension-labs/templates/exec-skill-template/skill.yaml
@@ -1,0 +1,17 @@
+metadata:
+  name: my-exec-skill
+  version: 0.1.0
+  description: Replace with your exec skill description.
+  author: Your Name
+runtime:
+  mode: exec
+  command: scripts/handler.sh
+capabilities:
+  bus:
+    subscribe:
+      - skill.exec.request
+    publish:
+      - skill.exec.response
+permissions:
+  - bus:publish
+  - bus:subscribe

--- a/community/extension-labs/templates/tinygo-skill-template/Makefile
+++ b/community/extension-labs/templates/tinygo-skill-template/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build validate clean
+
+build:
+	mkdir -p build
+	tinygo build -o build/my-skill.wasm -target=wasi ./src
+
+validate:
+	go run ./cmd/loqa-skill validate --file skill.yaml
+
+clean:
+	rm -rf build

--- a/community/extension-labs/templates/tinygo-skill-template/README.md
+++ b/community/extension-labs/templates/tinygo-skill-template/README.md
@@ -1,0 +1,19 @@
+# TinyGo Skill Template
+
+Starter template for building a WASM skill using TinyGo.
+
+## Contents
+- `skill.yaml` – placeholder manifest aligned with [`docs/skills/SPEC.md`](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md)
+- `src/main.go` – basic TinyGo entrypoint using the `host` helper
+- `Makefile` – build + validate targets
+
+## Usage
+
+```bash
+git clone https://github.com/ambiware-labs/loqa-core.git skills-lab
+cd skills-lab/community/extension-labs/templates/tinygo-skill-template
+make build
+make validate
+```
+
+> Replace the metadata, subjects, and permissions before publishing.

--- a/community/extension-labs/templates/tinygo-skill-template/skill.yaml
+++ b/community/extension-labs/templates/tinygo-skill-template/skill.yaml
@@ -1,0 +1,19 @@
+metadata:
+  name: my-skill
+  version: 0.1.0
+  description: Replace with your skill description.
+  author: Your Name
+runtime:
+  mode: wasm
+  module: build/my-skill.wasm
+  entrypoint: run
+  host_version: v1
+capabilities:
+  bus:
+    subscribe:
+      - skill.example.request
+    publish:
+      - skill.example.response
+permissions:
+  - bus:publish
+  - bus:subscribe

--- a/community/extension-labs/templates/tinygo-skill-template/src/main.go
+++ b/community/extension-labs/templates/tinygo-skill-template/src/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"syscall"
+
+	"github.com/ambiware-labs/loqa-core/skills/examples/internal/host"
+)
+
+type request struct {
+	Message string `json:"message"`
+}
+
+type response struct {
+	Reply string `json:"reply"`
+}
+
+func run() {
+	var req request
+	_ = json.Unmarshal([]byte(getEnv("LOQA_EVENT_PAYLOAD")), &req)
+
+	reply := response{Reply: "Hello from TinyGo!"}
+	payload, _ := json.Marshal(reply)
+
+	if host.Publish("skill.example.response", payload) {
+		host.Log("response published")
+	} else {
+		host.Log("publish failed")
+	}
+}
+
+func getEnv(key string) string {
+	if v, ok := syscall.Getenv(key); ok {
+		return v
+	}
+	return ""
+}
+
+//go:export run
+func main() {
+	run()
+}


### PR DESCRIPTION
## Summary
- add Extension Labs hub with quickstart workflow, showcase table, and templates for TinyGo/exec skills
- provide publishing checklist and update community README to link to the new hub

## Testing
- not applicable
