### PR TITLE
Add partner outreach pipeline

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -6,6 +6,10 @@ This directory will house guidelines, onboarding materials, and communication te
 
 Looking to build or share a skill? Visit [Extension Labs](extension-labs/README.md) for templates, best practices, and the community showcase.
 
+## Partner Outreach
+
+We’re building relationships with privacy-first and hardware-focused partners. See the [Partner Outreach Pipeline](outreach/partner_pipeline.md) for targets, messaging templates, and success metrics.
+
 ## GitHub Discussions
 
 Discussions are enabled on both [`loqa-core`](https://github.com/ambiware-labs/loqa-core/discussions) and [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta/discussions). Use the following categories when starting new threads:

--- a/community/outreach/partner_pipeline.md
+++ b/community/outreach/partner_pipeline.md
@@ -1,0 +1,67 @@
+# Partner Outreach Pipeline
+
+Issue reference: [loqa-meta#29](https://github.com/ambiware-labs/loqa-meta/issues/29)
+
+## Objectives
+- Engage hardware vendors, privacy communities, and integrators aligned with Loqa’s values.
+- Discover co-marketing and hardware bundle opportunities that support the hybrid open-core model.
+- Build a repeatable outreach and tracking process ahead of marketplace launch.
+
+## Target Partner Segments
+
+| Segment | Examples | Value Proposition |
+| --- | --- | --- |
+| DIY / IoT Hardware | Home Assistant Yellow, HomeSeer, Seeed Studio, Hardkernel | Ship Loqa-certified bundles, reference architectures, cross-promotion |
+| Privacy Communities | Privacy Guides, r/selfhosted mods, EFF supporters | Co-host events, cross-post launch content, gather feedback |
+| Boutique Installers | Smart-home integrators, small MSPs | Offer Loqa managed packages, observability dashboards, support retainers |
+| Component Vendors | Microphone array makers, NPU boards (Hailo, Coral) | Bundled peripherals, API integrations, co-branded kits |
+
+## Pipeline Tracking
+
+| Partner | Segment | Primary Contact | Status | Notes |
+| --- | --- | --- | --- | --- |
+| TBD | DIY Hardware |  | Identify |  |
+| TBD | Privacy Community |  | Identify |  |
+| TBD | Boutique Installer |  | Identify |  |
+
+> Update this table as conversations progress. Suggested statuses: *Identify → Intro → Discovery → Proposal → Live*.
+
+## Outreach Assets
+
+- **Intro deck (TODO):** Outline Loqa’s hybrid model, roadmap, and partner value.
+- **Email template:**
+  ```text
+  Subject: Exploring a local-first assistant partnership
+
+  Hi <name>,
+
+  I’m Anna from Ambiware Labs—the team behind Loqa, a local-first, open-core ambient intelligence platform. We noticed your work on <product/community> and think there’s a natural fit. We’d love to explore how Loqa’s privacy-first assistant stack could complement what you’re building.
+
+  A few highlights:
+  • MIT-licensed runtime + modular skills (like VS Code extensions)
+  • Optional value-add services (managed updates, premium packs) for sustainability
+  • Hardware-agnostic: runs across Macs, Minis, Pis, Jetsons—and soon certified bundles
+
+  Could we grab 30 minutes next week to swap notes?
+
+  Thanks,
+  Anna
+  Ambiware Labs / hello@ambiware.ai
+  ```
+- **One-pager (TODO):** Summarize Loqa for quick partner onboarding.
+
+## Immediate Next Steps
+1. Populate the pipeline with top 10 targets per segment (include contact emails/social).
+2. Draft intro deck + one-pager (link in this folder when complete).
+3. Schedule 3–5 exploratory calls in the next quarter.
+4. Sync with value-add roadmap (Workstream F) to align offerings before negotiations.
+
+## Success Metrics
+- 10 qualified partner conversations by end of Q4 2025.
+- 3 partnership pilots (hardware bundle, co-marketing, or service integration).
+- Feedback captured in Workstream F and marketplace planning.
+
+## References
+- [Value-add roadmap](../../roadmap/workstream-f/value_add_roadmap.md)
+- [Hybrid open-core announcement](https://ambiware.ai/blog/2025-09-28-loqa-hybrid-open-core-model.html)
+- [Marketplace RFC](../../rfcs/RFC-0003_loqa_marketplace_mvp.md)


### PR DESCRIPTION
## Summary
- create partner outreach pipeline doc with target segments, templates, and metrics
- link from community README for easy access

## Testing
- not applicable
