### PR TITLE
Add licensing philosophy doc

### DIFF
--- a/governance/licensing.md
+++ b/governance/licensing.md
@@ -1,0 +1,34 @@
+# Licensing Philosophy
+
+Loqa embraces a hybrid open-core model: the runtime and developer tooling remain permissively licensed, while optional value-add offerings fund ongoing development.
+
+## Core: MIT Licensed Forever
+
+- **Runtime (`loqa-core`)** – MIT license; run, fork, embed without restrictions.
+- **Protocols & SDKs** – MIT license to maximize compatibility.
+- **Documentation & templates** – Shared openly to encourage experimentation.
+- **Skills specification & CLI tools** – MIT license; no feature gating.
+
+## Value-Add Offerings (Optional)
+
+Loqa Studio delivers services that never compromise user control:
+
+| Offering | License / Access | Notes |
+| --- | --- | --- |
+| Loqa Cloud (encrypted sync) | Subscription | Opt-in, zero-trust design, end-to-end encryption. |
+| Studio bundles (personas, premium skills) | Commercial | Marketplace distribution with creator-defined licensing (OSS encouraged). |
+| Managed updates & support | Subscription | Signed releases, SLAs, enterprise onboarding. |
+| Pre-flashed hardware kits | Commercial | Convenience hardware with Loqa pre-configured.
+
+These offerings live outside the MIT-licensed core and never disable OSS deployments.
+
+## Contribution Assurance
+
+- Core UX, APIs, and developer experience are guaranteed to stay open.
+- Optional services are additive; no cloud dependency is required to run Loqa.
+- Community contributions remain MIT-licensed unless an author opts into a different license for marketplace content.
+
+## References
+- [Hybrid model announcement](https://ambiware.ai/blog/2025-09-28-loqa-hybrid-open-core-model.html)
+- [Marketplace RFC](../rfcs/RFC-0003_loqa_marketplace_mvp.md)
+- [Value-add roadmap](../roadmap/workstream-f/value_add_roadmap.md)


### PR DESCRIPTION
## Summary
- document the hybrid open-core licensing stance (MIT runtime + optional value-add offerings)
- clarify which components remain open vs. commercial
- link out to hybrid model announcement, marketplace RFC, and value-add roadmap

## Testing
- not applicable
