### PR TITLE
Add governance structure diagram

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -9,6 +9,7 @@ Loqa is an open-source project developed under the stewardship of Ambiware Labs.
 - [Licensing philosophy](licensing.md)
 - [Privacy & data principles](privacy.md)
 - [Project board guide](PROJECT_BOARD.md)
+- [Governance structure & diagram](structure.md)
 
 ## Project Roles
 

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -1,0 +1,42 @@
+# Governance Structure
+
+```mermaid
+graph TD
+    subgraph Community
+        Contributors --> RFC["RFC Draft"]
+        Contributors --> PRs["Pull Requests"]
+    end
+
+    RFC --> Review["Maintainer / Community Review"]
+    Review --> Decision{Decision}
+    Decision -->|Accepted| Implementation["Implementation & Tracking"]
+    Decision -->|Needs Rework| RFC
+    Decision -->|Rejected| Archive["Archive / Notes"]
+
+    Implementation --> Release["Release & Docs"]
+
+    subgraph Loqa Studio Governance
+        MarketplaceSubmit["Studio Submission"] --> Vetting["Safety & Quality Vetting"]
+        Vetting -->|Approved| Catalog["Marketplace Catalog"]
+        Vetting -->|Changes Requested| MarketplaceSubmit
+    end
+
+    Maintainers["Core Maintainers"] --> Review
+    Maintainers --> Vetting
+    FutureSteering["Future Steering Group"] -.-> Decision
+```
+
+## Roles & Responsibilities
+- **Contributors** – draft RFCs, submit code/docs, share Studio add-ons.
+- **Maintainers** – steward the roadmap, review RFCs, approve marketplace entries during the bootstrap phase.
+- **Future Steering Group** – will be established to share decision-making once the community grows; today it’s represented by maintainers.
+
+## Processes
+- **RFC Flow:** Submission → Discussion/Review → Decision → Implementation → Release.
+- **Marketplace Flow:** Submission → Vetting (quality, security, ethics) → Catalog publication.
+
+See also:
+- [Governance overview](README.md)
+- [Licensing philosophy](licensing.md)
+- [Privacy principles](privacy.md)
+- [Marketplace guidelines](../studio/README.md)


### PR DESCRIPTION
## Summary
- add `governance/structure.md` with a Mermaid diagram showing RFC and marketplace flows, roles, and future steering group
- link the new document from the governance README for discoverability

## Testing
- not applicable
