### PR TITLE
Align docs with Composable Open Core terminology

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -9,6 +9,7 @@ Loqa is an open-source project developed under the stewardship of Ambiware Labs.
 - [Licensing philosophy](licensing.md)
 - [Privacy & data principles](privacy.md)
 - [Project board guide](PROJECT_BOARD.md)
+- [Governance structure & diagram](structure.md)
 
 ## Project Roles
 

--- a/governance/licensing.md
+++ b/governance/licensing.md
@@ -1,6 +1,6 @@
 # Licensing Philosophy
 
-Loqa embraces a hybrid open-core model: the runtime and developer tooling remain permissively licensed, while optional value-add offerings fund ongoing development.
+Loqa embraces a **Composable Open Core** model: the runtime and developer tooling remain permissively licensed, while optional value-add offerings fund ongoing development without compromising user agency.
 
 ## Core: MIT Licensed Forever
 
@@ -20,7 +20,7 @@ Loqa Studio delivers services that never compromise user control:
 | Managed updates & support | Subscription | Signed releases, SLAs, enterprise onboarding. |
 | Pre-flashed hardware kits | Commercial | Convenience hardware with Loqa pre-configured.
 
-These offerings live outside the MIT-licensed core and never disable OSS deployments.
+These offerings live outside the MIT-licensed core and never disable OSS deployments—our promise of **Ethical Open Core**.
 
 ## Contribution Assurance
 

--- a/governance/structure.md
+++ b/governance/structure.md
@@ -1,0 +1,42 @@
+# Governance Structure
+
+```mermaid
+graph TD
+    subgraph Community
+        Contributors --> RFC["RFC Draft"]
+        Contributors --> PRs["Pull Requests"]
+    end
+
+    RFC --> Review["Maintainer / Community Review"]
+    Review --> Decision{Decision}
+    Decision -->|Accepted| Implementation["Implementation & Tracking"]
+    Decision -->|Needs Rework| RFC
+    Decision -->|Rejected| Archive["Archive / Notes"]
+
+    Implementation --> Release["Release & Docs"]
+
+    subgraph Loqa Studio Governance
+        MarketplaceSubmit["Studio Submission"] --> Vetting["Safety & Quality Vetting"]
+        Vetting -->|Approved| Catalog["Marketplace Catalog"]
+        Vetting -->|Changes Requested| MarketplaceSubmit
+    end
+
+    Maintainers["Core Maintainers"] --> Review
+    Maintainers --> Vetting
+    FutureSteering["Future Steering Group"] -.-> Decision
+```
+
+## Roles & Responsibilities
+- **Contributors** – draft RFCs, submit code/docs, share Studio add-ons.
+- **Maintainers** – steward the roadmap, review RFCs, approve marketplace entries during the bootstrap phase.
+- **Future Steering Group** – will be established to share decision-making once the community grows; today it’s represented by maintainers.
+
+## Processes
+- **RFC Flow:** Submission → Discussion/Review → Decision → Implementation → Release.
+- **Marketplace Flow:** Submission → Vetting (quality, security, ethics) → Catalog publication.
+
+See also:
+- [Governance overview](README.md)
+- [Licensing philosophy](licensing.md)
+- [Privacy principles](privacy.md)
+- [Marketplace guidelines](../studio/README.md)

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,6 +1,6 @@
 # Loqa Studio & Marketplace Guidelines
 
-This document complements [RFC-0003](../rfcs/RFC-0003_loqa_marketplace_mvp.md) by describing how creators can publish add-ons through Loqa Studio, and how Ambiware Labs vets submissions to keep the ecosystem safe and delightful.
+This document complements [RFC-0003](../rfcs/RFC-0003_loqa_marketplace_mvp.md) and the **Composable Open Core** strategy by describing how creators can publish add-ons through Loqa Studio, and how Ambiware Labs vets submissions to keep the ecosystem safe and delightful.
 
 ## What You Can Publish
 


### PR DESCRIPTION
## Summary
- update licensing philosophy to name the Composable Open Core / Ethical Open Core approach explicitly
- tweak the Studio guidelines intro to reference the strategy

## Testing
- not applicable
