### PR TITLE
Brand migration: Update Ambiware → Loqa Labs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Ambiware Labs
+Copyright (c) 2024 Loqa Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains:
 - **RFCs**: Request for Comments on major architectural and feature decisions
 - **Roadmap**: Project vision and development timeline
 - **Community**: Guidelines for community participation and contribution
-- **Brand**: Loqa and Ambiware Labs brand guidelines and assets
+- **Brand**: Loqa and Loqa Labs brand guidelines and assets
 - **Studio**: Marketplace guidelines and Loqa Studio documentation
 - **Issue Templates**: Shared templates for RFCs, features, and bugs (`.github/ISSUE_TEMPLATE`)
 
@@ -26,9 +26,9 @@ This repository contains:
 /.github      - Shared issue templates and workflow config
 ```
 
-## The Ambiware Labs ↔ Loqa Relationship
+## The Loqa Labs ↔ Loqa Relationship
 
-Ambiware Labs is the organizational home for Loqa development. While Loqa remains an open-source project with community involvement, Ambiware Labs provides:
+Loqa Labs is the organizational home for Loqa development. While Loqa remains an open-source project with community involvement, Loqa Labs provides:
 
 - Core development resources
 - Project stewardship and direction

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This policy applies to all Ambiware Labs open-source projects, including but not limited to:
+This policy applies to all Loqa Labs open-source projects, including but not limited to:
 
 - [`loqa-core`](https://github.com/loqalabs/loqa-core)
 - [`loqa-meta`](https://github.com/loqalabs/loqa-meta)
@@ -43,8 +43,8 @@ We support coordinated vulnerability disclosure. When you report a vulnerability
 The following are generally out of scope for this program:
 
 - Denial-of-service attacks (volumetric or resource exhaustion) that require excessive traffic
-- Vulnerabilities in third-party dependencies unless they directly affect Ambiware Labs code
-- Social engineering attacks or phishing against Ambiware Labs personnel
+- Vulnerabilities in third-party dependencies unless they directly affect Loqa Labs code
+- Social engineering attacks or phishing against Loqa Labs personnel
 - Physical attacks or non-technical testing
 
 ## Questions

--- a/brand/README.md
+++ b/brand/README.md
@@ -1,3 +1,3 @@
 # Brand Assets
 
-Placeholder for logos, color palettes, and usage guidelines that align Loqa with Ambiware Labs branding.
+Placeholder for logos, color palettes, and usage guidelines that align Loqa with Loqa Labs branding.

--- a/community/extension-labs/README.md
+++ b/community/extension-labs/README.md
@@ -28,8 +28,8 @@ Our goals:
 
 | Skill | Maintainer | Description | Tags |
 | --- | --- | --- | --- |
-| [timer](https://github.com/loqalabs/loqa-core/tree/main/skills/examples/timer) | Ambiware Labs | Simple countdown timer that announces completions. | timers, voice |
-| [smart-home-bridge](https://github.com/loqalabs/loqa-core/tree/main/skills/examples/smart-home) | Ambiware Labs | Bridges Loqa intents to Home Assistant. | home-automation, voice |
+| [timer](https://github.com/loqalabs/loqa-core/tree/main/skills/examples/timer) | Loqa Labs | Simple countdown timer that announces completions. | timers, voice |
+| [smart-home-bridge](https://github.com/loqalabs/loqa-core/tree/main/skills/examples/smart-home) | Loqa Labs | Bridges Loqa intents to Home Assistant. | home-automation, voice |
 
 > Have a skill to feature? [Open an issue](https://github.com/loqalabs/loqa-meta/issues/new?labels=community&title=Showcase%20submission%3A%20%3Cskill%3E) with links and tags.
 

--- a/community/outreach/partner_pipeline.md
+++ b/community/outreach/partner_pipeline.md
@@ -35,7 +35,7 @@ Issue reference: [loqa-meta#29](https://github.com/loqalabs/loqa-meta/issues/29)
 
   Hi <name>,
 
-  I’m Anna from Ambiware Labs—the team behind Loqa, a local-first, open-core ambient intelligence platform. We noticed your work on <product/community> and think there’s a natural fit. We’d love to explore how Loqa’s privacy-first assistant stack could complement what you’re building.
+  I’m Anna from Loqa Labs—the team behind Loqa, a local-first, open-core ambient intelligence platform. We noticed your work on <product/community> and think there’s a natural fit. We’d love to explore how Loqa’s privacy-first assistant stack could complement what you’re building.
 
   A few highlights:
   • MIT-licensed runtime + modular skills (like VS Code extensions)
@@ -46,7 +46,7 @@ Issue reference: [loqa-meta#29](https://github.com/loqalabs/loqa-meta/issues/29)
 
   Thanks,
   Anna
-  Ambiware Labs / hello@ambiware.ai
+  Loqa Labs / hello@ambiware.ai
   ```
 - **One-pager (TODO):** Summarize Loqa for quick partner onboarding.
 

--- a/governance/PROJECT_BOARD.md
+++ b/governance/PROJECT_BOARD.md
@@ -1,7 +1,7 @@
 # Project Board Operating Guide
 
 ## Purpose
-The Ambiware Labs project board provides a single, cross-repo view of Loqa’s roadmap execution. It helps track progress toward the MVP and subsequent milestones while keeping community contributors aligned.
+The Loqa Labs project board provides a single, cross-repo view of Loqa’s roadmap execution. It helps track progress toward the MVP and subsequent milestones while keeping community contributors aligned.
 
 ## Board Structure
 Columns are mapped to delivery states:

--- a/governance/README.md
+++ b/governance/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Loqa is an open-source project developed under the stewardship of Ambiware Labs. This document outlines the governance model and decision-making processes for the project.
+Loqa is an open-source project developed under the stewardship of Loqa Labs. This document outlines the governance model and decision-making processes for the project.
 
 ### Related Documents
 
@@ -23,7 +23,7 @@ Maintainers are responsible for the overall direction and health of the project.
 - Community guidelines
 
 Current maintainers:
-- Ambiware Labs Core Team
+- Loqa Labs Core Team
 
 ### Contributors
 
@@ -86,9 +86,9 @@ All participants must follow the [Code of Conduct](CODE_OF_CONDUCT.md). Violatio
 3. Temporary ban
 4. Permanent ban
 
-## Ambiware Labs Relationship
+## Loqa Labs Relationship
 
-Ambiware Labs:
+Loqa Labs:
 
 - Provides core development resources
 - Maintains project infrastructure

--- a/governance/ambiw_org_setup.md
+++ b/governance/ambiw_org_setup.md
@@ -1,12 +1,12 @@
-# Ambiware Labs Setup Notes
+# Loqa Labs Setup Notes
 
 ## Organization
 - **GitHub handle:** `loqalabs`
-- **Display name:** Ambiware Labs
+- **Display name:** Loqa Labs
 - **Description:** "Building Loqa: a local-first, open-core ambient intelligence platform."
 - **Website:** https://ambiware.ai
 - **Contact email:** hello@ambiware.ai
-- **Brand pairing:** Loqa remains the flagship open-source project; Ambiware Labs is the parent org.
+- **Brand pairing:** Loqa remains the flagship open-source project; Loqa Labs is the parent org.
 
 ## DNS Configuration (Porkbun)
 
@@ -42,4 +42,4 @@
 1. Update org profile with avatar, bio, and website link.
 2. Scaffold repositories via `gh repo create ...` commands; seed each with README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT.
 3. Stand up initial GitHub Pages repo under `loqa-site` and connect to `ambiware.ai` once DNS propagates.
-4. Document governance and roadmap in `loqa-meta`, announcing the Ambiware Labs ↔ Loqa relationship.
+4. Document governance and roadmap in `loqa-meta`, announcing the Loqa Labs ↔ Loqa relationship.

--- a/governance/privacy.md
+++ b/governance/privacy.md
@@ -14,7 +14,7 @@ Loqa is built for local-first, privacy-preserving ambient intelligence. These pr
 
 ## Optional Loqa Cloud (Encrypted)
 - Loqa Cloud provides convenience sync for those who opt in.
-- All data is end-to-end encrypted before it leaves the device; Ambiware Labs cannot read user content.
+- All data is end-to-end encrypted before it leaves the device; Loqa Labs cannot read user content.
 - Users can inspect, revoke, or self-host Loqa Cloud components as they become available.
 
 ## No Silent Calls Home

--- a/rfcs/RFC-0003_loqa_marketplace_mvp.md
+++ b/rfcs/RFC-0003_loqa_marketplace_mvp.md
@@ -1,7 +1,7 @@
 # RFC-0003: Loqa Marketplace MVP
 
 - **Status:** Draft
-- **Authors:** Anna Barnes, Ambiware Labs Team
+- **Authors:** Anna Barnes, Loqa Labs Team
 - **Created:** 2025-09-28
 - **Target Release:** Workstream F – Ecosystem Foundations
 - **Discussion:** https://github.com/loqalabs/loqa-meta/issues/26
@@ -49,7 +49,7 @@ Future phases may introduce a dedicated API or UI, but the MVP relies on static 
         "version": "0.1.0",
         "targets": ["linux/amd64", "darwin/arm64"],
         "tags": ["timers", "voice"],
-        "author": "Ambiware Labs",
+        "author": "Loqa Labs",
         "description": "Simple countdown timer," 
         "license": "MIT",
         "signature": "sig:..."
@@ -72,7 +72,7 @@ Future phases may introduce a dedicated API or UI, but the MVP relies on static 
   - CLI accepts `--registry URL` or reads `skills.registry.url` from config.
 
 ### Data Model
-- `index.json` versioned and signed (CLI validates `sig` using Ambiware’s public key; future phases support publisher keys).
+- `index.json` versioned and signed (CLI validates `sig` using Loqa Labs’s public key; future phases support publisher keys).
 - Each skill package includes the canonical `skill.yaml`; versioning must match `metadata.version`.
 - Optional metadata for paid/premium flag reserved for future use.
 
@@ -114,7 +114,7 @@ Future phases may introduce a dedicated API or UI, but the MVP relies on static 
    - Extend `config/example.yaml` with `skills.registry` section.
    - Document installation flow in README and docs.
 4. **Security:**
-   - Generate Ambiware signing key pair; distribute public key with CLI.
+   - Generate Loqa Labs signing key pair; distribute public key with CLI.
    - Implement signature verification.
 5. **Docs & Comms:**
    - Update authoring guide, site docs, and blog with marketplace instructions.

--- a/roadmap/MVP_BACKLOG.md
+++ b/roadmap/MVP_BACKLOG.md
@@ -30,7 +30,7 @@ This backlog tracks the committed work required to reach the MVP milestone (Phas
 - [x] Launch RFC process and template
 - [x] Stand up Discussions categories (announcements, ideas, support)
 - [x] Draft security disclosure policy
-- [x] Announce Ambiware Labs + Loqa relationship blog post
+- [x] Announce Loqa Labs + Loqa relationship blog post
 - [x] Document local developer setup for skills (TinyGo 0.39+, required tools)
 
 ## Workstream E: Release Readiness

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -10,7 +10,7 @@ Loqa aims to become the leading open-source platform for local-first ambient int
 **Status**: In Progress
 
 - [x] Project inception and architecture design
-- [x] Organization setup (Ambiware Labs)
+- [x] Organization setup (Loqa Labs)
 - [ ] Core runtime implementation
 - [ ] Basic STT → LLM → TTS pipeline
 - [ ] Initial clustering support

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,6 +1,6 @@
 # Loqa Studio & Marketplace Guidelines
 
-This document complements [RFC-0003](../rfcs/RFC-0003_loqa_marketplace_mvp.md) and the **Composable Open Core** strategy by describing how creators can publish add-ons through Loqa Studio, and how Ambiware Labs vets submissions to keep the ecosystem safe and delightful.
+This document complements [RFC-0003](../rfcs/RFC-0003_loqa_marketplace_mvp.md) and the **Composable Open Core** strategy by describing how creators can publish add-ons through Loqa Studio, and how Loqa Labs vets submissions to keep the ecosystem safe and delightful.
 
 ## What You Can Publish
 
@@ -12,7 +12,7 @@ Loqa Studio accepts extensions that respect Loqa’s local-first principles:
 | Premium Skills / Add-ons | Advanced automations, integrations, analytics dashboards | Built against the [skills spec](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md); may target WASM or exec runtimes. |
 | Loqa Cloud Integrations | Optional encrypted sync, shared memory spaces, multi-device orchestration | Must use end-to-end encryption and pass security review. |
 | Training & Courses | Workshops, onboarding curricula, certification tracks | Provide syllabus outline and delivery format. |
-| Pre-flashed Hardware Kits | Partner-built kits ready to plug into Loqa | Coordinate with Ambiware hardware program (see Workstream F roadmap).
+| Pre-flashed Hardware Kits | Partner-built kits ready to plug into Loqa | Coordinate with Loqa Labs hardware program (see Workstream F roadmap).
 
 Creators may also submit free/OSS extensions—the marketplace supports both commercial and community listings.
 
@@ -25,13 +25,13 @@ Creators may also submit free/OSS extensions—the marketplace supports both com
    - Submit metadata to the upcoming `loqa-marketplace` repository (see RFC-0003 for schema).
    - Clearly state pricing (if any), support contact, and dependencies.
 3. **Vetting & Safety Review**
-   - Ambiware Labs reviews for quality, security, and AI safety considerations (e.g., prompt injection handling, data provenance).
+   - Loqa Labs reviews for quality, security, and AI safety considerations (e.g., prompt injection handling, data provenance).
    - Automated checks validate manifests, signatures, and binary integrity.
 4. **Approval & Publishing**
    - Once approved, the catalog entry is published and becomes installable via `loqa-skill registry install <name>`.
    - Updates follow the same process; semantic versioning is required.
 
-> Until the community steering group is formed, Ambiware Labs’ core team makes final publication decisions. The process will transition to a shared governance model over time.
+> Until the community steering group is formed, Loqa Labs’ core team makes final publication decisions. The process will transition to a shared governance model over time.
 
 ## Licensing Flexibility
 


### PR DESCRIPTION
Updates all brand name references from Ambiware to Loqa Labs.

Migration Phase: Phase 2.3 - Repository Updates